### PR TITLE
Switch to ky from redaxios

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ This is a template project with best-practice modules:
 - Winterspec for defining the API
 - bun testing
 - Zustand store with zod definition for database state
+- [ky](https://github.com/sindresorhus/ky) as the HTTP client (used in test fixtures)


### PR DESCRIPTION
Closes #2

The repo already uses `ky` as the HTTP client in test fixtures. `redaxios` is not present anywhere in the codebase. This PR adds a README note to document `ky` as the chosen HTTP client.