### PR TITLE
test: await ky create request

### DIFF
--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -4,12 +4,16 @@ import { test, expect } from "bun:test"
 test("create a thing", async () => {
   const { ky } = await getTestServer()
 
-  ky.post("things/create", {
-    json: {
-      name: "Thing1",
-      description: "Thing1 Description",
-    },
-  })
+  const createResult = await ky
+    .post("things/create", {
+      json: {
+        name: "Thing1",
+        description: "Thing1 Description",
+      },
+    })
+    .json<{ ok: boolean }>()
+
+  expect(createResult).toEqual({ ok: true })
 
   const data = await ky
     .get("things/list")


### PR DESCRIPTION
## Summary
- await the Ky POST request before reading the created records
- parse and assert the Ky JSON response
- remove the race that can make the create/list test flaky

## Verification
- `git diff --check` passed
- Bun is not available in the local environment; GitHub Actions should run the project test suite

/claim #2

EVM payout address if supported: `0xa12c4fFe05Fa3355AdE1cC2110F9dAeEfcc7A0c2`