### PR TITLE
test: cover ky form delete flow

### DIFF
--- a/routes/things/delete.ts
+++ b/routes/things/delete.ts
@@ -1,6 +1,5 @@
 import { withRouteSpec } from "lib/middleware/with-winter-spec"
 import { z } from "zod"
-import type { DatabaseSchema } from "lib/db/schema"
 
 export default withRouteSpec({
   methods: ["POST"],

--- a/tests/routes/things/delete.test.ts
+++ b/tests/routes/things/delete.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("delete a thing with form data", async () => {
+  const { ky } = await getTestServer()
+
+  await ky.post("things/create", {
+    json: {
+      name: "Thing to delete",
+      description: "This thing should be deleted",
+    },
+  })
+
+  const created = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
+
+  expect(created.things).toHaveLength(1)
+
+  await ky.post("things/delete", {
+    body: new URLSearchParams({
+      thing_id: created.things[0]!.thing_id,
+    }),
+  })
+
+  const afterDelete = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
+
+  expect(afterDelete.things).toEqual([])
+})


### PR DESCRIPTION
## Summary
- add a ky-backed test for deleting a thing through the url-encoded form endpoint
- verify create -> list -> delete -> list so the migrated client covers POST form bodies
- remove an unused type import from the delete route

## Verification
- bun test
- bun run build
- bun run typecheck
- bun x biome format routes/things/delete.ts tests/routes/things/delete.test.ts

/claim #2

EVM payout address if supported: `0x9f7fFAd83668829FbC80c0a9a64f8557D92cA1E6`