### PR TITLE
test: await ky create request

### DIFF
--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -1,15 +1,19 @@
+import { expect, test } from "bun:test"
 import { getTestServer } from "tests/fixtures/get-test-server"
-import { test, expect } from "bun:test"
 
 test("create a thing", async () => {
   const { ky } = await getTestServer()
 
-  ky.post("things/create", {
-    json: {
-      name: "Thing1",
-      description: "Thing1 Description",
-    },
-  })
+  const createResponse = await ky
+    .post("things/create", {
+      json: {
+        name: "Thing1",
+        description: "Thing1 Description",
+      },
+    })
+    .json<{ ok: boolean }>()
+
+  expect(createResponse).toEqual({ ok: true })
 
   const data = await ky
     .get("things/list")


### PR DESCRIPTION
## Summary

/claim #2

- Awaits the ky `POST /things/create` request before listing created records.
- Parses and asserts the `{ ok: true }` JSON response from the migrated ky-backed route.
- Removes the create/list race from the existing route test.

## Validation

- `npx biome check tests/routes/things/create.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Note: this environment does not have `bun`, so I installed dependencies with `npm install --no-package-lock` for local validation without changing the lockfile. GitHub Actions should run the Bun test suite.