### PR TITLE
test: await ky create request

### DIFF
--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -4,16 +4,26 @@ import { test, expect } from "bun:test"
 test("create a thing", async () => {
   const { ky } = await getTestServer()
 
-  ky.post("things/create", {
-    json: {
+  const createData = await ky
+    .post("things/create", {
+      json: {
+        name: "Thing1",
+        description: "Thing1 Description",
+      },
+    })
+    .json<{ ok: boolean }>()
+
+  expect(createData.ok).toBe(true)
+
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
+
+  expect(data.things).toEqual([
+    {
+      thing_id: expect.any(String),
       name: "Thing1",
       description: "Thing1 Description",
     },
-  })
-
-  const data = await ky
-    .get("things/list")
-    .json<{ things: { name: string; description: string }[] }>()
-
-  expect(data.things).toHaveLength(1)
+  ])
 })


### PR DESCRIPTION
## Summary
- await the ky POST in the create-route regression test before listing things
- assert the create response body is `{ ok: true }`
- verify the created thing payload, including generated `thing_id`

## Validation
- `npx --yes bun test tests/routes/things/create.test.ts`
- `npx --yes bun x tsc --noEmit tests/routes/things/create.test.ts --types bun --moduleResolution bundler --module ESNext --target ESNext --baseUrl . --jsx preserve --allowImportingTsExtensions --noEmit --skipLibCheck`
- `npx --yes bun run build`
- `npx --yes bun x biome format tests/routes/things/create.test.ts`

/claim #2