### PR TITLE
test: await ky create route response

### DIFF
--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -4,12 +4,16 @@ import { test, expect } from "bun:test"
 test("create a thing", async () => {
   const { ky } = await getTestServer()
 
-  ky.post("things/create", {
-    json: {
-      name: "Thing1",
-      description: "Thing1 Description",
-    },
-  })
+  const createResponse = await ky
+    .post("things/create", {
+      json: {
+        name: "Thing1",
+        description: "Thing1 Description",
+      },
+    })
+    .json<{ ok: boolean }>()
+
+  expect(createResponse).toEqual({ ok: true })
 
   const data = await ky
     .get("things/list")


### PR DESCRIPTION
## Issue
Closes #2
/claim #2

## Summary
Tightens the ky create-route regression test by awaiting the POST response, asserting the `{ ok: true }` JSON body, and only then listing records. This keeps the ky migration coverage deterministic and avoids a create/list race.

## Verification
- `bun test`
- `PATH=/Users/eric/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run build`
- `PATH=/Users/eric/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run format:check`
- `PATH=/Users/eric/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node node_modules/typescript/bin/tsc --noEmit`