### PR TITLE
test: await ky post and add delete route test

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "debug-api",

--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -4,12 +4,16 @@ import { test, expect } from "bun:test"
 test("create a thing", async () => {
   const { ky } = await getTestServer()
 
-  ky.post("things/create", {
-    json: {
-      name: "Thing1",
-      description: "Thing1 Description",
-    },
-  })
+  const res = await ky
+    .post("things/create", {
+      json: {
+        name: "Thing1",
+        description: "Thing1 Description",
+      },
+    })
+    .json<{ ok: boolean }>()
+
+  expect(res.ok).toBe(true)
 
   const data = await ky
     .get("things/list")

--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -17,7 +17,9 @@ test("create a thing", async () => {
 
   const data = await ky
     .get("things/list")
-    .json<{ things: { thing_id: string; name: string; description: string }[] }>()
+    .json<{
+      things: { thing_id: string; name: string; description: string }[]
+    }>()
 
   expect(data.things).toEqual([
     {

--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -17,7 +17,13 @@ test("create a thing", async () => {
 
   const data = await ky
     .get("things/list")
-    .json<{ things: { name: string; description: string }[] }>()
+    .json<{ things: { thing_id: string; name: string; description: string }[] }>()
 
-  expect(data.things).toHaveLength(1)
+  expect(data.things).toEqual([
+    {
+      thing_id: "0",
+      name: "Thing1",
+      description: "Thing1 Description",
+    },
+  ])
 })

--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -15,11 +15,9 @@ test("create a thing", async () => {
 
   expect(res.ok).toBe(true)
 
-  const data = await ky
-    .get("things/list")
-    .json<{
-      things: { thing_id: string; name: string; description: string }[]
-    }>()
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
 
   expect(data.things).toEqual([
     {

--- a/tests/routes/things/delete.test.ts
+++ b/tests/routes/things/delete.test.ts
@@ -1,0 +1,42 @@
+import { getTestServer } from "tests/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("delete a thing", async () => {
+  const { ky } = await getTestServer()
+
+  // 1. Create a thing first
+  const createRes = await ky
+    .post("things/create", {
+      json: {
+        name: "Thing to Delete",
+        description: "This thing will be deleted",
+      },
+    })
+    .json<{ ok: boolean }>()
+
+  expect(createRes.ok).toBe(true)
+
+  // 2. List the things to get its generated thing_id
+  const listBefore = await ky
+    .get("things/list")
+    .json<{ things: { thing_id: string; name: string }[] }>()
+
+  expect(listBefore.things).toHaveLength(1)
+  const thingId = listBefore.things[0].thing_id
+
+  // 3. Delete the thing using URL-encoded form data
+  const deleteRes = await ky
+    .post("things/delete", {
+      body: new URLSearchParams({ thing_id: thingId }),
+    })
+    .json<{ ok: boolean }>()
+
+  expect(deleteRes.ok).toBe(true)
+
+  // 4. Verify that the list is empty now
+  const listAfter = await ky
+    .get("things/list")
+    .json<{ things: { thing_id: string; name: string }[] }>()
+
+  expect(listAfter.things).toHaveLength(0)
+})

--- a/tests/routes/things/delete.test.ts
+++ b/tests/routes/things/delete.test.ts
@@ -40,3 +40,34 @@ test("delete a thing", async () => {
 
   expect(listAfter.things).toHaveLength(0)
 })
+
+test("delete is a no-op for unknown thing ids", async () => {
+  const { ky } = await getTestServer()
+
+  await ky.post("things/create", {
+    json: {
+      name: "Thing1",
+      description: "Thing1 Description",
+    },
+  })
+
+  const deleteResponse = await ky
+    .post("things/delete", {
+      body: new URLSearchParams({ thing_id: "missing" }),
+    })
+    .json<{ ok: boolean }>()
+
+  expect(deleteResponse).toEqual({ ok: true })
+
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
+
+  expect(data.things).toEqual([
+    {
+      thing_id: "0",
+      name: "Thing1",
+      description: "Thing1 Description",
+    },
+  ])
+})

--- a/tests/routes/things/list.test.ts
+++ b/tests/routes/things/list.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("list starts empty", async () => {
+  const { ky } = await getTestServer()
+
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
+
+  expect(data.things).toEqual([])
+})
+
+test("list preserves insertion order and generated ids", async () => {
+  const { ky } = await getTestServer()
+
+  await ky.post("things/create", {
+    json: {
+      name: "Thing1",
+      description: "Thing1 Description",
+    },
+  })
+  await ky.post("things/create", {
+    json: {
+      name: "Thing2",
+      description: "Thing2 Description",
+    },
+  })
+
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
+
+  expect(data.things).toEqual([
+    {
+      thing_id: "0",
+      name: "Thing1",
+      description: "Thing1 Description",
+    },
+    {
+      thing_id: "1",
+      name: "Thing2",
+      description: "Thing2 Description",
+    },
+  ])
+})


### PR DESCRIPTION
## Summary
- Awaits the `ky.post` creation request in `create.test.ts` to prevent race conditions and asserts `{ ok: true }`.
- Adds `tests/routes/things/delete.test.ts` to cover the delete route with URL-encoded form data and verify deletion using `ky`.

/claim #2