### PR TITLE
test: await ky create route response

### DIFF
--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -3,17 +3,24 @@ import { test, expect } from "bun:test"
 
 test("create a thing", async () => {
   const { ky } = await getTestServer()
+  const thing = {
+    name: "Thing1",
+    description: "Thing1 Description",
+  }
 
-  ky.post("things/create", {
-    json: {
-      name: "Thing1",
-      description: "Thing1 Description",
-    },
-  })
+  const createData = await ky
+    .post("things/create", {
+      json: thing,
+    })
+    .json<{ ok: boolean }>()
+
+  expect(createData).toEqual({ ok: true })
 
   const data = await ky
     .get("things/list")
     .json<{ things: { name: string; description: string }[] }>()
 
   expect(data.things).toHaveLength(1)
+  expect(data.things[0]?.name).toBe(thing.name)
+  expect(data.things[0]?.description).toBe(thing.description)
 })

--- a/tests/routes/things/delete.test.ts
+++ b/tests/routes/things/delete.test.ts
@@ -13,11 +13,9 @@ test("delete a thing by id and ignore missing ids", async () => {
     })
     .json<{ ok: boolean }>()
 
-  const beforeDelete = await ky
-    .get("things/list")
-    .json<{
-      things: { thing_id: string; name: string; description: string }[]
-    }>()
+  const beforeDelete = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
 
   expect(beforeDelete.things).toHaveLength(1)
 

--- a/tests/routes/things/delete.test.ts
+++ b/tests/routes/things/delete.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("delete a thing by id and ignore missing ids", async () => {
+  const { ky } = await getTestServer()
+
+  await ky
+    .post("things/create", {
+      json: {
+        name: "Thing1",
+        description: "Thing1 Description",
+      },
+    })
+    .json<{ ok: boolean }>()
+
+  const beforeDelete = await ky
+    .get("things/list")
+    .json<{
+      things: { thing_id: string; name: string; description: string }[]
+    }>()
+
+  expect(beforeDelete.things).toHaveLength(1)
+
+  const deleteData = await ky
+    .post("things/delete", {
+      body: new URLSearchParams({
+        thing_id: beforeDelete.things[0]!.thing_id,
+      }),
+    })
+    .json<{ ok: boolean }>()
+
+  expect(deleteData).toEqual({ ok: true })
+
+  const afterDelete = await ky.get("things/list").json<{ things: unknown[] }>()
+  expect(afterDelete.things).toHaveLength(0)
+
+  const missingDeleteData = await ky
+    .post("things/delete", {
+      body: new URLSearchParams({
+        thing_id: "missing",
+      }),
+    })
+    .json<{ ok: boolean }>()
+
+  expect(missingDeleteData).toEqual({ ok: true })
+
+  const data = await ky.get("things/list").json<{ things: unknown[] }>()
+  expect(data.things).toHaveLength(0)
+})

--- a/tests/routes/things/list.test.ts
+++ b/tests/routes/things/list.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("list starts empty and returns created things in insertion order", async () => {
+  const { ky } = await getTestServer()
+
+  const emptyData = await ky.get("things/list").json<{ things: unknown[] }>()
+
+  expect(emptyData.things).toEqual([])
+
+  const things = [
+    {
+      name: "Thing1",
+      description: "Thing1 Description",
+    },
+    {
+      name: "Thing2",
+      description: "Thing2 Description",
+    },
+  ]
+
+  for (const thing of things) {
+    const createData = await ky
+      .post("things/create", {
+        json: thing,
+      })
+      .json<{ ok: boolean }>()
+
+    expect(createData).toEqual({ ok: true })
+  }
+
+  const data = await ky
+    .get("things/list")
+    .json<{
+      things: { thing_id: string; name: string; description: string }[]
+    }>()
+
+  expect(data.things).toEqual([
+    {
+      thing_id: "0",
+      ...things[0],
+    },
+    {
+      thing_id: "1",
+      ...things[1],
+    },
+  ])
+})

--- a/tests/routes/things/list.test.ts
+++ b/tests/routes/things/list.test.ts
@@ -29,11 +29,9 @@ test("list starts empty and returns created things in insertion order", async ()
     expect(createData).toEqual({ ok: true })
   }
 
-  const data = await ky
-    .get("things/list")
-    .json<{
-      things: { thing_id: string; name: string; description: string }[]
-    }>()
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
 
   expect(data.things).toEqual([
     {


### PR DESCRIPTION
## Summary

/claim #2

This tightens the existing ky-backed create route regression test:

- await the `POST /things/create` ky request before listing things
- assert the create route returns `{ ok: true }`
- verify the persisted thing name and description after listing

The previous test fired the ky POST without awaiting it, so the immediate list request could race the create request and make the coverage nondeterministic.

## Verification

- `git diff --check`

I could not run the Bun test suite locally because `bun` is not installed on PATH.