### PR TITLE
test: await ky create request

### DIFF
--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -4,16 +4,24 @@ import { test, expect } from "bun:test"
 test("create a thing", async () => {
   const { ky } = await getTestServer()
 
-  ky.post("things/create", {
-    json: {
-      name: "Thing1",
-      description: "Thing1 Description",
-    },
-  })
+  const createData = await ky
+    .post("things/create", {
+      json: {
+        name: "Thing1",
+        description: "Thing1 Description",
+      },
+    })
+    .json<{ ok: boolean }>()
+
+  expect(createData).toEqual({ ok: true })
 
   const data = await ky
     .get("things/list")
     .json<{ things: { name: string; description: string }[] }>()
 
   expect(data.things).toHaveLength(1)
+  expect(data.things[0]).toMatchObject({
+    name: "Thing1",
+    description: "Thing1 Description",
+  })
 })


### PR DESCRIPTION
## Summary
- Await the ky-backed `things/create` POST in the create route regression test.
- Assert the `{ ok: true }` JSON response before listing things.
- Verify the persisted thing fields so the create/list sequence is deterministic.

## Validation
- `bun test tests/routes/things/create.test.ts`
- `bun test tests/routes/health.test.ts`
- `bun run format:check`
- `git diff --check`

Closes #2
/claim #2