### PR TITLE
test: strengthen ky route coverage

### DIFF
--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -4,16 +4,25 @@ import { test, expect } from "bun:test"
 test("create a thing", async () => {
   const { ky } = await getTestServer()
 
-  ky.post("things/create", {
-    json: {
-      name: "Thing1",
-      description: "Thing1 Description",
-    },
-  })
+  const createResponse = await ky
+    .post("things/create", {
+      json: {
+        name: "Thing1",
+        description: "Thing1 Description",
+      },
+    })
+    .json<{ ok: boolean }>()
 
-  const data = await ky
-    .get("things/list")
-    .json<{ things: { name: string; description: string }[] }>()
+  expect(createResponse).toEqual({ ok: true })
+
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
 
   expect(data.things).toHaveLength(1)
+  expect(data.things[0]).toMatchObject({
+    name: "Thing1",
+    description: "Thing1 Description",
+  })
+  expect(data.things[0]?.thing_id).toBeString()
 })

--- a/tests/routes/things/delete.test.ts
+++ b/tests/routes/things/delete.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("delete a thing with ky form data", async () => {
+  const { ky } = await getTestServer()
+  const name = `Thing to delete ${crypto.randomUUID()}`
+
+  await ky.post("things/create", {
+    json: {
+      name,
+      description: "Temporary thing",
+    },
+  })
+
+  const beforeDelete = await ky
+    .get("things/list")
+    .json<{ things: { thing_id: string; name: string }[] }>()
+
+  const thingId = beforeDelete.things.find(
+    (thing) => thing.name === name,
+  )?.thing_id
+  expect(thingId).toBeString()
+
+  const deleteResponse = await ky
+    .post("things/delete", {
+      body: new URLSearchParams({ thing_id: thingId! }),
+    })
+    .json<{ ok: boolean }>()
+
+  expect(deleteResponse).toEqual({ ok: true })
+
+  const afterDelete = await ky
+    .get("things/list")
+    .json<{ things: { thing_id: string; name: string }[] }>()
+
+  expect(afterDelete.things.some((thing) => thing.name === name)).toBe(false)
+})


### PR DESCRIPTION
## Summary
- await and validate the ky-backed create request before listing records
- assert the persisted record fields and generated ID
- add end-to-end coverage for ky URL-encoded form submission to the delete route
- make the delete test resilient to concurrently created records

## Validation
- `bun test` - 3 passed, 0 failed
- `winterspec bundle -o dist/bundle.js` - passed
- `tsc --noEmit` - passed
- `biome format tests/routes/things/create.test.ts tests/routes/things/delete.test.ts` - passed

/claim #2