### PR TITLE
test: harden ky create test and cover delete/list routes

### DIFF
--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -1,19 +1,27 @@
 import { getTestServer } from "tests/fixtures/get-test-server"
 import { test, expect } from "bun:test"
 
-test("create a thing", async () => {
+test("create a thing persists and lists deterministically", async () => {
   const { ky } = await getTestServer()
 
-  ky.post("things/create", {
-    json: {
-      name: "Thing1",
-      description: "Thing1 Description",
-    },
-  })
+  const createRes = await ky
+    .post("things/create", {
+      json: {
+        name: "Thing1",
+        description: "Thing1 Description",
+      },
+    })
+    .json<{ ok: boolean }>()
 
-  const data = await ky
-    .get("things/list")
-    .json<{ things: { name: string; description: string }[] }>()
+  expect(createRes).toEqual({ ok: true })
+
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
 
   expect(data.things).toHaveLength(1)
+  expect(data.things[0].name).toBe("Thing1")
+  expect(data.things[0].description).toBe("Thing1 Description")
+  expect(typeof data.things[0].thing_id).toBe("string")
+  expect(data.things[0].thing_id.length).toBeGreaterThan(0)
 })

--- a/tests/routes/things/delete.test.ts
+++ b/tests/routes/things/delete.test.ts
@@ -1,0 +1,65 @@
+import { getTestServer } from "tests/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("delete a thing removes it from the list", async () => {
+  const { ky } = await getTestServer()
+
+  await ky
+    .post("things/create", {
+      json: { name: "ToDelete", description: "Will be removed" },
+    })
+    .json<{ ok: boolean }>()
+
+  await ky
+    .post("things/create", {
+      json: { name: "ToKeep", description: "Stays" },
+    })
+    .json<{ ok: boolean }>()
+
+  const before = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
+  expect(before.things).toHaveLength(2)
+
+  const target = before.things.find((t) => t.name === "ToDelete")
+  expect(target).toBeDefined()
+
+  const deleteRes = await ky
+    .post("things/delete", {
+      body: new URLSearchParams({ thing_id: target!.thing_id }),
+    })
+    .json<{ ok: boolean }>()
+  expect(deleteRes).toEqual({ ok: true })
+
+  const after = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
+  expect(after.things).toHaveLength(1)
+  expect(after.things[0].name).toBe("ToKeep")
+  expect(
+    after.things.find((t) => t.thing_id === target!.thing_id),
+  ).toBeUndefined()
+})
+
+test("delete is a no-op when thing_id does not exist", async () => {
+  const { ky } = await getTestServer()
+
+  await ky
+    .post("things/create", {
+      json: { name: "Solo", description: "only one" },
+    })
+    .json<{ ok: boolean }>()
+
+  const res = await ky
+    .post("things/delete", {
+      body: new URLSearchParams({ thing_id: "does-not-exist" }),
+    })
+    .json<{ ok: boolean }>()
+  expect(res).toEqual({ ok: true })
+
+  const after = await ky
+    .get("things/list")
+    .json<{ things: { thing_id: string; name: string }[] }>()
+  expect(after.things).toHaveLength(1)
+  expect(after.things[0].name).toBe("Solo")
+})

--- a/tests/routes/things/list.test.ts
+++ b/tests/routes/things/list.test.ts
@@ -1,0 +1,35 @@
+import { getTestServer } from "tests/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("list returns an empty array when no things exist", async () => {
+  const { ky } = await getTestServer()
+
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
+
+  expect(data.things).toEqual([])
+})
+
+test("list returns things in insertion order with incrementing thing_id", async () => {
+  const { ky } = await getTestServer()
+
+  const names = ["Alpha", "Bravo", "Charlie"]
+  for (const name of names) {
+    await ky
+      .post("things/create", {
+        json: { name, description: `${name} desc` },
+      })
+      .json<{ ok: boolean }>()
+  }
+
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
+
+  expect(data.things.map((t) => t.name)).toEqual(names)
+  // thing_id is generated from an incrementing counter
+  const ids = data.things.map((t) => Number(t.thing_id))
+  expect(ids).toEqual([...ids].sort((a, b) => a - b))
+  expect(new Set(ids).size).toBe(ids.length)
+})


### PR DESCRIPTION
## Summary

/claim #2

Builds on the prior ky-migration test work by removing the remaining race in the create test and filling in coverage for the two `things` routes that had no tests.

### `tests/routes/things/create.test.ts`
- Awaits the `ky.post("things/create", …)` call so the create completes before `things/list` runs (previously fire-and-forget, the assertion only passed by accident on fast paths).
- Asserts the create response body equals `{ ok: true }`.
- After listing, verifies the persisted `name`, `description`, and that `thing_id` is a non-empty string — covers the full create → persist → list contract.

### `tests/routes/things/delete.test.ts` (new)
- Creates two things, deletes one by `thing_id` via URL-encoded form data, asserts `{ ok: true }` and that only the surviving thing remains.
- Adds a no-op case: deleting a non-existent `thing_id` still returns `{ ok: true }` and leaves existing data untouched.

### `tests/routes/things/list.test.ts` (new)
- Empty-list case returns `{ things: [] }`.
- Multi-create case verifies things come back in insertion order and that `thing_id` values are unique and monotonically increasing (matches the `idCounter` behavior in `lib/db/db-client.ts`).

## Validation

```
$ bun test
 6 pass
 0 fail
 21 expect() calls

$ bun run format:check
 Checked 24 files in 12ms. No fixes applied.
```

No production code changed; tests only.

Closes #2