### PR TITLE
test: harden ky coverage for create/delete/list routes

### DIFF
--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -1,5 +1,5 @@
+import { expect, test } from "bun:test"
 import { getTestServer } from "tests/fixtures/get-test-server"
-import { test, expect } from "bun:test"
 
 test("create a thing persists and returns ok", async () => {
   const { ky } = await getTestServer()
@@ -15,9 +15,9 @@ test("create a thing persists and returns ok", async () => {
   const body = await res.json<{ ok: boolean }>()
   expect(body).toEqual({ ok: true })
 
-  const data = await ky
-    .get("things/list")
-    .json<{ things: { thing_id: string; name: string; description: string }[] }>()
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
 
   expect(data.things).toHaveLength(1)
   expect(data.things[0].name).toBe("Thing1")
@@ -37,9 +37,9 @@ test("create assigns incrementing thing_ids", async () => {
     expect(res).toEqual({ ok: true })
   }
 
-  const data = await ky
-    .get("things/list")
-    .json<{ things: { thing_id: string; name: string }[] }>()
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string }[]
+  }>()
 
   expect(data.things).toHaveLength(3)
   expect(data.things.map((t) => t.name)).toEqual(names)
@@ -55,9 +55,10 @@ test("create accepts empty string fields", async () => {
     .json<{ ok: boolean }>()
   expect(res).toEqual({ ok: true })
 
-  const data = await ky
-    .get("things/list")
-    .json<{ things: { name: string; description: string }[] }>()
+  const data = await ky.get("things/list").json<{
+    things: { name: string; description: string }[]
+  }>()
+
   expect(data.things).toHaveLength(1)
   expect(data.things[0].name).toBe("")
   expect(data.things[0].description).toBe("")

--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -1,19 +1,64 @@
 import { getTestServer } from "tests/fixtures/get-test-server"
 import { test, expect } from "bun:test"
 
-test("create a thing", async () => {
+test("create a thing persists and returns ok", async () => {
   const { ky } = await getTestServer()
 
-  ky.post("things/create", {
+  const res = await ky.post("things/create", {
     json: {
       name: "Thing1",
       description: "Thing1 Description",
     },
   })
+  expect(res.status).toBe(200)
+
+  const body = await res.json<{ ok: boolean }>()
+  expect(body).toEqual({ ok: true })
+
+  const data = await ky
+    .get("things/list")
+    .json<{ things: { thing_id: string; name: string; description: string }[] }>()
+
+  expect(data.things).toHaveLength(1)
+  expect(data.things[0].name).toBe("Thing1")
+  expect(data.things[0].description).toBe("Thing1 Description")
+  expect(typeof data.things[0].thing_id).toBe("string")
+  expect(data.things[0].thing_id.length).toBeGreaterThan(0)
+})
+
+test("create assigns incrementing thing_ids", async () => {
+  const { ky } = await getTestServer()
+
+  const names = ["Alpha", "Bravo", "Charlie"]
+  for (const name of names) {
+    const res = await ky
+      .post("things/create", { json: { name, description: `${name} desc` } })
+      .json<{ ok: boolean }>()
+    expect(res).toEqual({ ok: true })
+  }
+
+  const data = await ky
+    .get("things/list")
+    .json<{ things: { thing_id: string; name: string }[] }>()
+
+  expect(data.things).toHaveLength(3)
+  expect(data.things.map((t) => t.name)).toEqual(names)
+  const ids = data.things.map((t) => Number(t.thing_id))
+  expect(ids).toEqual([0, 1, 2])
+})
+
+test("create accepts empty string fields", async () => {
+  const { ky } = await getTestServer()
+
+  const res = await ky
+    .post("things/create", { json: { name: "", description: "" } })
+    .json<{ ok: boolean }>()
+  expect(res).toEqual({ ok: true })
 
   const data = await ky
     .get("things/list")
     .json<{ things: { name: string; description: string }[] }>()
-
   expect(data.things).toHaveLength(1)
+  expect(data.things[0].name).toBe("")
+  expect(data.things[0].description).toBe("")
 })

--- a/tests/routes/things/delete.test.ts
+++ b/tests/routes/things/delete.test.ts
@@ -1,0 +1,91 @@
+import { getTestServer } from "tests/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("delete removes a thing by thing_id", async () => {
+  const { ky } = await getTestServer()
+
+  await ky
+    .post("things/create", {
+      json: { name: "ToDelete", description: "Will be removed" },
+    })
+    .json<{ ok: boolean }>()
+
+  await ky
+    .post("things/create", {
+      json: { name: "ToKeep", description: "Stays" },
+    })
+    .json<{ ok: boolean }>()
+
+  const before = await ky
+    .get("things/list")
+    .json<{ things: { thing_id: string; name: string }[] }>()
+  expect(before.things).toHaveLength(2)
+
+  const targetId = before.things.find((t) => t.name === "ToDelete")!.thing_id
+  const delRes = await ky
+    .post("things/delete", {
+      body: new URLSearchParams({ thing_id: targetId }),
+    })
+    .json<{ ok: boolean }>()
+  expect(delRes).toEqual({ ok: true })
+
+  const after = await ky
+    .get("things/list")
+    .json<{ things: { name: string }[] }>()
+  expect(after.things).toHaveLength(1)
+  expect(after.things[0].name).toBe("ToKeep")
+})
+
+test("delete is idempotent for non-existent thing_id", async () => {
+  const { ky } = await getTestServer()
+
+  await ky
+    .post("things/create", {
+      json: { name: "OnlyOne", description: "only one" },
+    })
+    .json<{ ok: boolean }>()
+
+  const res = await ky
+    .post("things/delete", {
+      body: new URLSearchParams({ thing_id: "does-not-exist" }),
+    })
+    .json<{ ok: boolean }>()
+  expect(res).toEqual({ ok: true })
+
+  const after = await ky
+    .get("things/list")
+    .json<{ things: { name: string }[] }>()
+  expect(after.things).toHaveLength(1)
+  expect(after.things[0].name).toBe("OnlyOne")
+})
+
+test("create after delete gets a new incrementing thing_id", async () => {
+  const { ky } = await getTestServer()
+
+  const c1 = await ky
+    .post("things/create", { json: { name: "Temp", description: "t" } })
+    .json<{ ok: boolean }>()
+  expect(c1).toEqual({ ok: true })
+
+  const l1 = await ky
+    .get("things/list")
+    .json<{ things: { thing_id: string }[] }>()
+  const deletedId = l1.things[0].thing_id
+
+  await ky
+    .post("things/delete", {
+      body: new URLSearchParams({ thing_id: deletedId }),
+    })
+    .json<{ ok: boolean }>()
+
+  const c2 = await ky
+    .post("things/create", { json: { name: "New", description: "n" } })
+    .json<{ ok: boolean }>()
+  expect(c2).toEqual({ ok: true })
+
+  const l2 = await ky
+    .get("things/list")
+    .json<{ things: { thing_id: string }[] }>()
+  expect(l2.things).toHaveLength(1)
+  expect(l2.things[0].thing_id).not.toBe(deletedId)
+})

--- a/tests/routes/things/delete.test.ts
+++ b/tests/routes/things/delete.test.ts
@@ -1,5 +1,5 @@
+import { expect, test } from "bun:test"
 import { getTestServer } from "tests/fixtures/get-test-server"
-import { test, expect } from "bun:test"
 
 test("delete removes a thing by thing_id", async () => {
   const { ky } = await getTestServer()
@@ -16,9 +16,9 @@ test("delete removes a thing by thing_id", async () => {
     })
     .json<{ ok: boolean }>()
 
-  const before = await ky
-    .get("things/list")
-    .json<{ things: { thing_id: string; name: string }[] }>()
+  const before = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string }[]
+  }>()
   expect(before.things).toHaveLength(2)
 
   const targetId = before.things.find((t) => t.name === "ToDelete")!.thing_id
@@ -29,9 +29,9 @@ test("delete removes a thing by thing_id", async () => {
     .json<{ ok: boolean }>()
   expect(delRes).toEqual({ ok: true })
 
-  const after = await ky
-    .get("things/list")
-    .json<{ things: { name: string }[] }>()
+  const after = await ky.get("things/list").json<{
+    things: { name: string }[]
+  }>()
   expect(after.things).toHaveLength(1)
   expect(after.things[0].name).toBe("ToKeep")
 })
@@ -52,9 +52,9 @@ test("delete is idempotent for non-existent thing_id", async () => {
     .json<{ ok: boolean }>()
   expect(res).toEqual({ ok: true })
 
-  const after = await ky
-    .get("things/list")
-    .json<{ things: { name: string }[] }>()
+  const after = await ky.get("things/list").json<{
+    things: { name: string }[]
+  }>()
   expect(after.things).toHaveLength(1)
   expect(after.things[0].name).toBe("OnlyOne")
 })
@@ -67,9 +67,9 @@ test("create after delete gets a new incrementing thing_id", async () => {
     .json<{ ok: boolean }>()
   expect(c1).toEqual({ ok: true })
 
-  const l1 = await ky
-    .get("things/list")
-    .json<{ things: { thing_id: string }[] }>()
+  const l1 = await ky.get("things/list").json<{
+    things: { thing_id: string }[]
+  }>()
   const deletedId = l1.things[0].thing_id
 
   await ky
@@ -83,9 +83,9 @@ test("create after delete gets a new incrementing thing_id", async () => {
     .json<{ ok: boolean }>()
   expect(c2).toEqual({ ok: true })
 
-  const l2 = await ky
-    .get("things/list")
-    .json<{ things: { thing_id: string }[] }>()
+  const l2 = await ky.get("things/list").json<{
+    things: { thing_id: string }[]
+  }>()
   expect(l2.things).toHaveLength(1)
   expect(l2.things[0].thing_id).not.toBe(deletedId)
 })

--- a/tests/routes/things/list.test.ts
+++ b/tests/routes/things/list.test.ts
@@ -1,12 +1,12 @@
+import { expect, test } from "bun:test"
 import { getTestServer } from "tests/fixtures/get-test-server"
-import { test, expect } from "bun:test"
 
 test("list returns empty array on fresh server", async () => {
   const { ky } = await getTestServer()
 
-  const data = await ky
-    .get("things/list")
-    .json<{ things: { thing_id: string; name: string; description: string }[] }>()
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
 
   expect(data.things).toEqual([])
 })
@@ -20,9 +20,9 @@ test("list returns all required fields for each thing", async () => {
     })
     .json<{ ok: boolean }>()
 
-  const data = await ky
-    .get("things/list")
-    .json<{ things: { thing_id: string; name: string; description: string }[] }>()
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
 
   expect(data.things).toHaveLength(1)
   const t = data.things[0]
@@ -42,9 +42,9 @@ test("list preserves insertion order", async () => {
       .json<{ ok: boolean }>()
   }
 
-  const data = await ky
-    .get("things/list")
-    .json<{ things: { name: string }[] }>()
+  const data = await ky.get("things/list").json<{
+    things: { name: string }[]
+  }>()
 
   expect(data.things.map((t) => t.name)).toEqual(names)
 })
@@ -58,9 +58,9 @@ test("list reflects create and delete in sequence", async () => {
       .json<{ ok: boolean }>()
   }
 
-  const listed = await ky
-    .get("things/list")
-    .json<{ things: { thing_id: string; name: string }[] }>()
+  const listed = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string }[]
+  }>()
   const bId = listed.things.find((t) => t.name === "B")!.thing_id
   await ky
     .post("things/delete", {
@@ -68,8 +68,8 @@ test("list reflects create and delete in sequence", async () => {
     })
     .json<{ ok: boolean }>()
 
-  const final = await ky
-    .get("things/list")
-    .json<{ things: { name: string }[] }>()
+  const final = await ky.get("things/list").json<{
+    things: { name: string }[]
+  }>()
   expect(final.things.map((t) => t.name)).toEqual(["A", "C"])
 })

--- a/tests/routes/things/list.test.ts
+++ b/tests/routes/things/list.test.ts
@@ -1,0 +1,75 @@
+import { getTestServer } from "tests/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("list returns empty array on fresh server", async () => {
+  const { ky } = await getTestServer()
+
+  const data = await ky
+    .get("things/list")
+    .json<{ things: { thing_id: string; name: string; description: string }[] }>()
+
+  expect(data.things).toEqual([])
+})
+
+test("list returns all required fields for each thing", async () => {
+  const { ky } = await getTestServer()
+
+  await ky
+    .post("things/create", {
+      json: { name: "Widget", description: "A widget" },
+    })
+    .json<{ ok: boolean }>()
+
+  const data = await ky
+    .get("things/list")
+    .json<{ things: { thing_id: string; name: string; description: string }[] }>()
+
+  expect(data.things).toHaveLength(1)
+  const t = data.things[0]
+  expect(typeof t.thing_id).toBe("string")
+  expect(t.thing_id.length).toBeGreaterThan(0)
+  expect(t.name).toBe("Widget")
+  expect(t.description).toBe("A widget")
+})
+
+test("list preserves insertion order", async () => {
+  const { ky } = await getTestServer()
+
+  const names = ["Alpha", "Bravo", "Charlie"]
+  for (const name of names) {
+    await ky
+      .post("things/create", { json: { name, description: `${name} desc` } })
+      .json<{ ok: boolean }>()
+  }
+
+  const data = await ky
+    .get("things/list")
+    .json<{ things: { name: string }[] }>()
+
+  expect(data.things.map((t) => t.name)).toEqual(names)
+})
+
+test("list reflects create and delete in sequence", async () => {
+  const { ky } = await getTestServer()
+
+  for (const name of ["A", "B", "C"]) {
+    await ky
+      .post("things/create", { json: { name, description: `${name} desc` } })
+      .json<{ ok: boolean }>()
+  }
+
+  const listed = await ky
+    .get("things/list")
+    .json<{ things: { thing_id: string; name: string }[] }>()
+  const bId = listed.things.find((t) => t.name === "B")!.thing_id
+  await ky
+    .post("things/delete", {
+      body: new URLSearchParams({ thing_id: bId }),
+    })
+    .json<{ ok: boolean }>()
+
+  const final = await ky
+    .get("things/list")
+    .json<{ things: { name: string }[] }>()
+  expect(final.things.map((t) => t.name)).toEqual(["A", "C"])
+})


### PR DESCRIPTION
/claim #2

## Summary
Fixes and expands test coverage for the ky HTTP client migration bounty (#2):

### create.test.ts (rewritten)
- Fixed a race condition: `ky.post()` was not awaited
- Added proper HTTP response and body assertions
- Added `thing_id` to response type
- 2 new tests: incrementing thing_ids, empty string acceptance

### delete.test.ts (new, 3 tests)
- Delete removes correct thing by thing_id
- Idempotent for non-existent IDs
- New create after delete gets fresh ID

### list.test.ts (new, 4 tests)
- Empty array on fresh server
- Full field validation
- Insertion order preserved
- CRUD sequence consistency

All tests use ky throughout, follow existing getTestServer pattern.

Closes #2