### PR TITLE
test: strengthen ky things route coverage

### DIFF
--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -4,16 +4,26 @@ import { test, expect } from "bun:test"
 test("create a thing", async () => {
   const { ky } = await getTestServer()
 
-  ky.post("things/create", {
-    json: {
+  const createResponse = await ky
+    .post("things/create", {
+      json: {
+        name: "Thing1",
+        description: "Thing1 Description",
+      },
+    })
+    .json<{ ok: boolean }>()
+
+  expect(createResponse).toEqual({ ok: true })
+
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
+
+  expect(data.things).toEqual([
+    {
+      thing_id: "0",
       name: "Thing1",
       description: "Thing1 Description",
     },
-  })
-
-  const data = await ky
-    .get("things/list")
-    .json<{ things: { name: string; description: string }[] }>()
-
-  expect(data.things).toHaveLength(1)
+  ])
 })

--- a/tests/routes/things/delete.test.ts
+++ b/tests/routes/things/delete.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("delete a thing with ky form data", async () => {
+  const { ky } = await getTestServer()
+
+  await ky.post("things/create", {
+    json: {
+      name: "Thing1",
+      description: "Thing1 Description",
+    },
+  })
+  await ky.post("things/create", {
+    json: {
+      name: "Thing2",
+      description: "Thing2 Description",
+    },
+  })
+
+  const deleteResponse = await ky
+    .post("things/delete", {
+      body: new URLSearchParams({ thing_id: "0" }),
+    })
+    .json<{ ok: boolean }>()
+
+  expect(deleteResponse).toEqual({ ok: true })
+
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
+
+  expect(data.things).toEqual([
+    {
+      thing_id: "1",
+      name: "Thing2",
+      description: "Thing2 Description",
+    },
+  ])
+})
+
+test("delete is a no-op for unknown thing ids", async () => {
+  const { ky } = await getTestServer()
+
+  await ky.post("things/create", {
+    json: {
+      name: "Thing1",
+      description: "Thing1 Description",
+    },
+  })
+
+  const deleteResponse = await ky
+    .post("things/delete", {
+      body: new URLSearchParams({ thing_id: "missing" }),
+    })
+    .json<{ ok: boolean }>()
+
+  expect(deleteResponse).toEqual({ ok: true })
+
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
+
+  expect(data.things).toEqual([
+    {
+      thing_id: "0",
+      name: "Thing1",
+      description: "Thing1 Description",
+    },
+  ])
+})

--- a/tests/routes/things/list.test.ts
+++ b/tests/routes/things/list.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("list starts empty", async () => {
+  const { ky } = await getTestServer()
+
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
+
+  expect(data.things).toEqual([])
+})
+
+test("list preserves insertion order and generated ids", async () => {
+  const { ky } = await getTestServer()
+
+  await ky.post("things/create", {
+    json: {
+      name: "Thing1",
+      description: "Thing1 Description",
+    },
+  })
+  await ky.post("things/create", {
+    json: {
+      name: "Thing2",
+      description: "Thing2 Description",
+    },
+  })
+
+  const data = await ky.get("things/list").json<{
+    things: { thing_id: string; name: string; description: string }[]
+  }>()
+
+  expect(data.things).toEqual([
+    {
+      thing_id: "0",
+      name: "Thing1",
+      description: "Thing1 Description",
+    },
+    {
+      thing_id: "1",
+      name: "Thing2",
+      description: "Thing2 Description",
+    },
+  ])
+})


### PR DESCRIPTION
## Summary
- await and assert the ky create response before listing things
- add ky form-body coverage for the delete route
- add list route coverage for empty state, insertion order, and generated ids

## Tests
- bun test
- bun run build
- bun run typecheck
- bun run format:check

/claim #2