### PR TITLE
fix: support admin form creates

### DIFF
--- a/routes/things/create.ts
+++ b/routes/things/create.ts
@@ -1,17 +1,28 @@
 import { withRouteSpec } from "lib/middleware/with-winter-spec"
 import { z } from "zod"
 
+const createThingSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+})
+
 export default withRouteSpec({
   methods: ["POST"],
-  jsonBody: z.object({
-    name: z.string(),
-    description: z.string(),
-  }),
+  jsonBody: createThingSchema.optional(),
+  urlEncodedFormData: createThingSchema.optional(),
   jsonResponse: z.object({
     ok: z.boolean(),
   }),
 })(async (req, ctx) => {
-  const { name, description } = await req.json()
+  const thing = req.jsonBody ?? req.urlEncodedFormData
+
+  if (!thing) {
+    return new Response("Expected JSON or URL-encoded form data", {
+      status: 400,
+    })
+  }
+
+  const { name, description } = thing
   ctx.db.addThing({
     name,
     description,

--- a/tests/routes/things/create.test.ts
+++ b/tests/routes/things/create.test.ts
@@ -4,16 +4,49 @@ import { test, expect } from "bun:test"
 test("create a thing", async () => {
   const { ky } = await getTestServer()
 
-  ky.post("things/create", {
-    json: {
-      name: "Thing1",
-      description: "Thing1 Description",
-    },
-  })
+  const response = await ky
+    .post("things/create", {
+      json: {
+        name: "Thing1",
+        description: "Thing1 Description",
+      },
+    })
+    .json<{ ok: boolean }>()
+
+  expect(response).toEqual({ ok: true })
 
   const data = await ky
     .get("things/list")
     .json<{ things: { name: string; description: string }[] }>()
 
   expect(data.things).toHaveLength(1)
+  expect(data.things[0]).toMatchObject({
+    name: "Thing1",
+    description: "Thing1 Description",
+  })
+})
+
+test("create a thing from url encoded form data", async () => {
+  const { ky } = await getTestServer()
+
+  const response = await ky
+    .post("things/create", {
+      body: new URLSearchParams({
+        name: "Admin Thing",
+        description: "Created from the admin form",
+      }),
+    })
+    .json<{ ok: boolean }>()
+
+  expect(response).toEqual({ ok: true })
+
+  const data = await ky
+    .get("things/list")
+    .json<{ things: { name: string; description: string }[] }>()
+
+  expect(data.things).toHaveLength(1)
+  expect(data.things[0]).toMatchObject({
+    name: "Admin Thing",
+    description: "Created from the admin form",
+  })
 })


### PR DESCRIPTION
Fixes a remaining create-route gap in the ky-backed API path: the admin page posts `application/x-www-form-urlencoded` data to `/things/create`, but the route only accepted JSON.

Changes:
- share the create request schema across JSON and URL-encoded form bodies
- keep JSON API creation working and assert the response in the existing ky test
- add a ky regression test for admin-style URL-encoded form creation
- return a 400 if neither supported body type is provided

Validation:
- `bun test tests/routes/things/create.test.ts`
- `bun test`
- `bun run build`
- `bunx tsc --noEmit`
- `bun run format:check`
- `git diff --check`

/claim #2